### PR TITLE
Playtest fixes

### DIFF
--- a/Pareidolia/Assets/Canvas UI/DialogueUIUpdater.cs
+++ b/Pareidolia/Assets/Canvas UI/DialogueUIUpdater.cs
@@ -5,12 +5,16 @@ public class DialogueUIUpdater : MonoBehaviour
 {
     [SerializeField] private TMP_Text dialogueField;
     [SerializeField] private GameObject textbox;
-    int MSG_TIME = 5;
+    int MSG_TIME = 7;
     float timetodisappear;
+    private bool _tutMSG = false;
 
     void Update()
     {
-        if (dialogueField.enabled && Time.time >= timetodisappear)
+        if (_tutMSG)
+        {
+            // don't make tutorial msg disappear
+        } else if (dialogueField.enabled && Time.time >= timetodisappear)
         {
             dialogueField.enabled = false;
             textbox.SetActive(false);
@@ -20,24 +24,40 @@ public class DialogueUIUpdater : MonoBehaviour
     void OnEnable()
     {
         ObjectInteraction.DialoguePromptEvent += UpdateDialogueText;
-        TutorialManager.TutorialDialogueEvent += UpdateDialogueText;
+        TutorialManager.TutorialDialogueEvent += TutorialTextEnable;
+        NoteInteraction.NotepadPickedUp += TutorialTextDisable;
         BasementDoorScriptedEvent.BasementDoorDialogueEvent += UpdateDialogueText;
     }
 
     void OnDisable()
     {
         ObjectInteraction.DialoguePromptEvent -= UpdateDialogueText;
-        TutorialManager.TutorialDialogueEvent -= UpdateDialogueText;
+        TutorialManager.TutorialDialogueEvent -= TutorialTextEnable;
+        NoteInteraction.NotepadPickedUp -= TutorialTextDisable;
         BasementDoorScriptedEvent.BasementDoorDialogueEvent -= UpdateDialogueText;
     }
 
     private void UpdateDialogueText(string msg)
     {
         dialogueField.text = msg;
-        EnableText();
+        EnableTempText();
     }
 
-    private void EnableText()
+    private void TutorialTextEnable(string msg)
+    {
+        dialogueField.text = msg;
+        _tutMSG = true;
+        EnableTempText();
+    }
+
+    private void TutorialTextDisable()
+    {
+        dialogueField.enabled = false;
+        textbox.SetActive(false);
+        _tutMSG = false;
+    }
+
+    private void EnableTempText()
     {
         dialogueField.enabled = true;
         textbox.SetActive(true);

--- a/Pareidolia/Assets/Canvas UI/ToDoListNotification.prefab
+++ b/Pareidolia/Assets/Canvas UI/ToDoListNotification.prefab
@@ -1,0 +1,250 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &543820068902999824
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 9060381244315688954}
+  - component: {fileID: 4191807722561327912}
+  - component: {fileID: 298074598957548981}
+  m_Layer: 5
+  m_Name: NotiBox
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &9060381244315688954
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 543820068902999824}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 7.0108, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1236254129045022929}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -749.14, y: 315}
+  m_SizeDelta: {x: 60.154, y: 74}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &4191807722561327912
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 543820068902999824}
+  m_CullTransparentMesh: 1
+--- !u!114 &298074598957548981
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 543820068902999824}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.8415094, g: 0.7665743, b: 0.5763545, a: 0.41960785}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &3429416249519640705
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1236254129045022929}
+  m_Layer: 5
+  m_Name: ToDoListNotification
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1236254129045022929
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3429416249519640705}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 9060381244315688954}
+  - {fileID: 6935203811001809280}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &7155642740175660282
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6935203811001809280}
+  - component: {fileID: 2588122748976109918}
+  - component: {fileID: 7612283525103913349}
+  m_Layer: 5
+  m_Name: ToDoListUpdated
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6935203811001809280
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7155642740175660282}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1236254129045022929}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -403, y: 316}
+  m_SizeDelta: {x: 1000, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2588122748976109918
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7155642740175660282}
+  m_CullTransparentMesh: 1
+--- !u!114 &7612283525103913349
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7155642740175660282}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: To-do list updated!
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4278190080
+  m_fontColor: {r: 0, g: 0, b: 0, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 40
+  m_fontSizeBase: 40
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 641.40405, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}

--- a/Pareidolia/Assets/Canvas UI/ToDoListNotification.prefab.meta
+++ b/Pareidolia/Assets/Canvas UI/ToDoListNotification.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a591e72eccdd67b449bd6d66cd1f7d7f
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Pareidolia/Assets/Canvas UI/TodoListNotiManager.cs
+++ b/Pareidolia/Assets/Canvas UI/TodoListNotiManager.cs
@@ -1,0 +1,29 @@
+using UnityEngine;
+
+public class TodoListNotiManager : MonoBehaviour
+{
+    [SerializeField] private GameObject notification;
+
+    private void DisableNotification()
+    {
+        notification.SetActive(false);
+        Destroy(this);
+    }
+    
+    private void EnableNotification()
+    {
+        notification.SetActive(true);
+    }
+
+    void OnEnable()
+    {
+        UpdateUI.TasksUpdatedEvent += EnableNotification;
+        OpenCloseNote.NotepadFirstCheckEvent += DisableNotification;
+    }
+
+    void OnDisable()
+    {
+        UpdateUI.TasksUpdatedEvent -= EnableNotification;
+        OpenCloseNote.NotepadFirstCheckEvent += DisableNotification;
+    }
+}

--- a/Pareidolia/Assets/Canvas UI/TodoListNotiManager.cs.meta
+++ b/Pareidolia/Assets/Canvas UI/TodoListNotiManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5e636f56112b9134481cb936ecd74307

--- a/Pareidolia/Assets/NoteTasklist/OpenCloseNote.cs
+++ b/Pareidolia/Assets/NoteTasklist/OpenCloseNote.cs
@@ -1,6 +1,7 @@
 using UnityEngine;
 using UnityEngine.InputSystem;
 using FMODUnity;
+using System;
 
 /// <summary>
 /// Script for opening and closing notes
@@ -11,9 +12,10 @@ public class OpenCloseNote : MonoBehaviour
     Renderer tasklist;
     [SerializeField] private GameObject tasklistcanvas;
     public EventReference tasklistsfx;
-
+    private bool _firstOpen = true;
     private bool noteOpen = false;
     [SerializeField] private bool notePickedUp = false;
+    public static event Action NotepadFirstCheckEvent;
 
     private void Start() 
     {
@@ -32,8 +34,12 @@ public class OpenCloseNote : MonoBehaviour
         // stop player from moving while reading
         AudioManager.instance.PlayOneShot(tasklistsfx, this.transform.position);
         // Play sfx whenever the player opens their tasklist
-
         noteOpen = true;
+        if (_firstOpen)
+        {
+            NotepadFirstCheckEvent?.Invoke();
+            _firstOpen = false;
+        }
     }
 
     private void CloseNote()

--- a/Pareidolia/Assets/NoteTasklist/UpdateUI.cs
+++ b/Pareidolia/Assets/NoteTasklist/UpdateUI.cs
@@ -1,11 +1,13 @@
 using UnityEngine;
 using TMPro;
+using System;
 
 public class UpdateUI: MonoBehaviour
 {
     [SerializeField] private TMP_Text[] notepadTextFields; // size 7
     [SerializeField] private string[] notepadText; // size 7
     // have a "Don't Look at the faces" images visible?
+    public static event Action TasksUpdatedEvent;
     
 
     /*
@@ -40,7 +42,6 @@ public class UpdateUI: MonoBehaviour
             notepadText[2] = "Take a shower";
         }
         updateTasks();
-
     }
 
     private void OnEnable() 
@@ -100,5 +101,6 @@ public class UpdateUI: MonoBehaviour
         {
             notepadTextFields[txtfield].text = notepadText[txtfield];
         }
+        TasksUpdatedEvent?.Invoke();
     }
 }

--- a/Pareidolia/Assets/Scenes/Level Scenes/MorningLevel.unity
+++ b/Pareidolia/Assets/Scenes/Level Scenes/MorningLevel.unity
@@ -296,6 +296,7 @@ RectTransform:
   m_LocalScale: {x: 0, y: 0, z: 0}
   m_ConstrainProportionsScale: 0
   m_Children:
+  - {fileID: 1142328396}
   - {fileID: 696533695}
   - {fileID: 1962239075}
   - {fileID: 2474758327064132144}
@@ -2258,6 +2259,121 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 8162528181456408172, guid: 27cc536bf0922d1409c128db4217e50e, type: 3}
   m_PrefabInstance: {fileID: 1117184678}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1142328394
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 123701329}
+    m_Modifications:
+    - target: {fileID: 1236254129045022929, guid: a591e72eccdd67b449bd6d66cd1f7d7f, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1236254129045022929, guid: a591e72eccdd67b449bd6d66cd1f7d7f, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1236254129045022929, guid: a591e72eccdd67b449bd6d66cd1f7d7f, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1236254129045022929, guid: a591e72eccdd67b449bd6d66cd1f7d7f, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1236254129045022929, guid: a591e72eccdd67b449bd6d66cd1f7d7f, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1236254129045022929, guid: a591e72eccdd67b449bd6d66cd1f7d7f, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1236254129045022929, guid: a591e72eccdd67b449bd6d66cd1f7d7f, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 1236254129045022929, guid: a591e72eccdd67b449bd6d66cd1f7d7f, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 1236254129045022929, guid: a591e72eccdd67b449bd6d66cd1f7d7f, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1236254129045022929, guid: a591e72eccdd67b449bd6d66cd1f7d7f, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1236254129045022929, guid: a591e72eccdd67b449bd6d66cd1f7d7f, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1236254129045022929, guid: a591e72eccdd67b449bd6d66cd1f7d7f, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1236254129045022929, guid: a591e72eccdd67b449bd6d66cd1f7d7f, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1236254129045022929, guid: a591e72eccdd67b449bd6d66cd1f7d7f, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1236254129045022929, guid: a591e72eccdd67b449bd6d66cd1f7d7f, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1236254129045022929, guid: a591e72eccdd67b449bd6d66cd1f7d7f, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1236254129045022929, guid: a591e72eccdd67b449bd6d66cd1f7d7f, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1236254129045022929, guid: a591e72eccdd67b449bd6d66cd1f7d7f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1236254129045022929, guid: a591e72eccdd67b449bd6d66cd1f7d7f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1236254129045022929, guid: a591e72eccdd67b449bd6d66cd1f7d7f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3429416249519640705, guid: a591e72eccdd67b449bd6d66cd1f7d7f, type: 3}
+      propertyPath: m_Name
+      value: ToDoListNotification
+      objectReference: {fileID: 0}
+    - target: {fileID: 3429416249519640705, guid: a591e72eccdd67b449bd6d66cd1f7d7f, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7155642740175660282, guid: a591e72eccdd67b449bd6d66cd1f7d7f, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a591e72eccdd67b449bd6d66cd1f7d7f, type: 3}
+--- !u!1 &1142328395 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3429416249519640705, guid: a591e72eccdd67b449bd6d66cd1f7d7f, type: 3}
+  m_PrefabInstance: {fileID: 1142328394}
+  m_PrefabAsset: {fileID: 0}
+--- !u!224 &1142328396 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 1236254129045022929, guid: a591e72eccdd67b449bd6d66cd1f7d7f, type: 3}
+  m_PrefabInstance: {fileID: 1142328394}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1186912929 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 8792261052398437847, guid: e272706fd09599e45bb5321214a086cc, type: 3}
@@ -4143,6 +4259,51 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 4936798360749730376, guid: 6819eb049cfa99e47ab61e329868fed8, type: 3}
   m_PrefabInstance: {fileID: 1730824468}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1753669669
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1753669671}
+  - component: {fileID: 1753669670}
+  m_Layer: 0
+  m_Name: ToDoListNotiManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1753669670
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1753669669}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5e636f56112b9134481cb936ecd74307, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  notification: {fileID: 1142328395}
+--- !u!4 &1753669671
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1753669669}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 773.7364, y: 715.31226, z: -600.06445}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1758843093
 GameObject:
   m_ObjectHideFlags: 0
@@ -6421,3 +6582,4 @@ SceneRoots:
   - {fileID: 1373605228}
   - {fileID: 5524556281714177836}
   - {fileID: 393223024}
+  - {fileID: 1753669671}


### PR DESCRIPTION
Adjusts the initial dialogue msg at the start of the game to persist until the player picks up the notepad (Note: the msg still disappears if the player triggers another dialogue message)

Also adds a preliminary notification in the top left screen that tells the player the to-do list has been updated at the start of every lvl